### PR TITLE
Make dataDir's existence known

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ myCollection.set("myKey", "a value");
 let result = myCollection.get("myKey");
 ```
 
+Optionally - Choose the directory in which a PersistentCollection stores data:
+
+```js
+const myCollection = new PersistentCollection({name: 'myCollection', dataDir: './user_info/'});
+```
+
 Some important notes: 
 - If the collection `name` already exists, *its keys and values loaded in memory*.
 - If it does not exist, it is initialized (with no values).

--- a/index.js
+++ b/index.js
@@ -7,7 +7,17 @@ const path = require("path");
  * @extends {Collection}
  */
 class PersistentCollection extends Collection {
+  /**
+   * @typedef PersistentCollectionOptions
+   * @property {string} name - Unique database name
+   * @property {string} [dataDir="./data"] - Directory where data is stored
+   */
 
+  /**
+   * Creates a new Collection that saves its data to a file.
+   * @param {*} [iterable] - Iterable Object to initialize Collection from
+   * @param {PersistentCollectionOptions} options - Options for database name and location
+   */
   constructor(iterable, options = {}) {
     if (typeof iterable[Symbol.iterator] !== 'function') {
         options = iterable || {};
@@ -51,6 +61,9 @@ class PersistentCollection extends Collection {
     });
   }
   
+  /**
+   * Closes database cleanly ensuring data is saved.
+   */
   close() {
     this.db.close();
   }


### PR DESCRIPTION
I had to look at the source to see if you could change the ./data directory to somewhere else manually.

Apparently you could so I added JSDoc to the constructor options so it now autocompletes.
I also added a small mention of the feature to README.md

This PR contains documentation changes ONLY.